### PR TITLE
S48-667: Blank line before return

### DIFF
--- a/rulesets/.eslintrc
+++ b/rulesets/.eslintrc
@@ -6,6 +6,7 @@
         "indent": ["error", 4],
         "semi": [2, "always"],
         "yoda": ["error", "never"],
+        "newline-before-return": "error",
         "no-tabs": "error",
         "camelcase": "error",
         "max-len": ["error", { "code": 120,  "comments": 150 }],

--- a/rulesets/PhpCs/Space48Extra/Sniffs/BlankLineBeforeReturnSniff.php
+++ b/rulesets/PhpCs/Space48Extra/Sniffs/BlankLineBeforeReturnSniff.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Space48\CodeQuality\RuleSets\PhpCs\Space48Extra\Sniffs;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File as CodeSnifferFile;
+
+class BlankLineBeforeReturnSniff implements Sniff
+{
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array(
+        'PHP',
+        'JS',
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_RETURN);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param CodeSnifferFile $phpcsFile All the tokens found in the document.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(CodeSnifferFile $phpcsFile, $stackPtr)
+    {
+        $tokens          = $phpcsFile->getTokens();
+        $current         = $stackPtr;
+        $previousLine    = $tokens[$stackPtr]['line'] - 1;
+        $prevLineTokens  = array();
+
+        while ($current >= 0 && $tokens[$current]['line'] >= $previousLine) {
+            if ($tokens[$current]['line'] == $previousLine
+                && $tokens[$current]['type'] !== 'T_WHITESPACE'
+                && $tokens[$current]['type'] !== 'T_COMMENT'
+            ) {
+                $prevLineTokens[] = $tokens[$current]['type'];
+            }
+            $current--;
+        }
+
+        if (isset($prevLineTokens[0])
+            && ($prevLineTokens[0] === 'T_OPEN_CURLY_BRACKET'
+                || $prevLineTokens[0] === 'T_COLON')
+        ) {
+            return;
+        } else if (count($prevLineTokens) > 0) {
+            $fix = $phpcsFile->addFixableError(
+                'Missing blank line before return statement',
+                $stackPtr,
+                'MissedBlankLineBeforeRetrun'
+            );
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $i = 1;
+                while($tokens[$stackPtr-$i]['type'] == "T_WHITESPACE") {
+                    $i++;
+                }
+                $phpcsFile->fixer->addNewLine($stackPtr-$i);
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+        return;
+    }
+}

--- a/rulesets/PhpCs/Space48Extra/extra.xml
+++ b/rulesets/PhpCs/Space48Extra/extra.xml
@@ -6,4 +6,6 @@
             <property name="set" value="compiler_optimized" />
         </properties>
     </rule>
+    <rule ref="vendor/space48/magento2-code-quality/rulesets/PhpCs/Space48Extra/Sniffs/BlankLineBeforeReturnSniff.php">
+    </rule>
 </ruleset>

--- a/src/Configuration/FixerConfig.php
+++ b/src/Configuration/FixerConfig.php
@@ -7,7 +7,7 @@ class FixerConfig extends \GrumPHP\Configuration\Model\FixerConfig
     /**
      * {@inheritdoc }
      */
-    public static function fromArray(array $config): self
+    public static function fromArray(array $config): \GrumPHP\Configuration\Model\FixerConfig
     {
         return new self(
             ($config['enabled'] ?? false),


### PR DESCRIPTION
- Add sniff from 'https://github.com/lapistano/Symfony2-coding-standard/blob/master/Sniffs/Formatting/BlankLineBeforeReturnSniff.php'
- bug fix in FixerConfig