### PR TITLE
Fix "Not a TTY device" issue in precommit hook

### DIFF
--- a/githooks/warden/pre-commit
+++ b/githooks/warden/pre-commit
@@ -6,4 +6,4 @@
 DIFF=$(git -c diff.mnemonicprefix=false -c diff.noprefix=false --no-pager diff -r -p -m -M --full-index --no-color --staged | cat)
 
 # Run GrumPHP
-[ "$DIFF" == '' ] || (cd "./" && printf "%s\n" "${DIFF}" | warden env run --rm php-fpm 'vendor/phpro/grumphp/bin/grumphp' 'git:pre-commit' '--skip-success-output')
+[ "$DIFF" == '' ] || (cd "./" && printf "%s\n" "${DIFF}" | warden env exec -T php-fpm 'vendor/phpro/grumphp/bin/grumphp' 'git:pre-commit' '--skip-success-output')


### PR DESCRIPTION
This issue was fixed in the makefile code-quality.mk But the hook used by vendor/space48/magento2-code-quality/script/add-hook.sh was not updated